### PR TITLE
Modify the logic of replace name and id pattern from parents

### DIFF
--- a/vendor/assets/javascripts/jquery_nested_form.js
+++ b/vendor/assets/javascripts/jquery_nested_form.js
@@ -33,11 +33,11 @@
         for(var i = 0; i < parentNames.length; i++) {
           if(parentIds[i]) {
             content = content.replace(
-              new RegExp('(_' + parentNames[i] + ')_.+?_', 'g'),
+              new RegExp('(_' + parentNames[i] + ')_[0-9]+?_', 'g'),
               '$1_' + parentIds[i] + '_');
 
             content = content.replace(
-              new RegExp('(\\[' + parentNames[i] + '\\])\\[.+?\\]', 'g'),
+              new RegExp('(\\[' + parentNames[i] + '\\])\\[[0-9]+?\\]', 'g'),
               '$1[' + parentIds[i] + ']');
           }
         }


### PR DESCRIPTION
After blueprint is created, remained job is to replace name and id with mapped patterns from parents.

### Previous logic
* get patterns from parents, then replace them in blueprint layer by layer.
* The potential risks are association name of different layers can be same or different, so it is possible to replace wrong patterns.

### Current logic
* get patterns from parents, knock together a full name and id pattern regular expression of all upstair layers. 
* replace the part that matched by this regexp with full name and id pattern from parents
* replace the remained name and id part of the current layer with a timestamp. 
